### PR TITLE
Improve village transformer

### DIFF
--- a/data/divider-words.csv
+++ b/data/divider-words.csv
@@ -16,7 +16,7 @@ kel
 KEPBUP
 keputusan
 klarifikasi
-koreksi
+koreksi,koreksin
 lampiran
 letak
 menjadi

--- a/src/divider-words.ts
+++ b/src/divider-words.ts
@@ -3,7 +3,7 @@ import { extractTxtFileRows } from './extractor.js';
 
 interface DividerWordsOptions {
   withTypos?: boolean
-  excludedWords?: string[]
+  excludedWords?: readonly string[]
 }
 
 export default function getDividerWords(options?: DividerWordsOptions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,8 +181,9 @@ export default async function idnxtr(options: ExtractorOptions) {
   }
 
   const unparseOptions: Papa.UnparseConfig = {
-    escapeChar: '\\',
+    escapeChar: '',
     newline: '\n',
+    quoteChar: '',
   };
 
   let transformer: Transformer;

--- a/src/transformer/VillageTransformer.ts
+++ b/src/transformer/VillageTransformer.ts
@@ -3,13 +3,22 @@ import getDividerWords from '~/divider-words.js';
 import { Transformer } from './index.js';
 
 export default class VillageTransformer implements Transformer<Village, VillageCsv> {
+  getDividerWords() {
+    return getDividerWords({
+      withTypos: true,
+      excludedWords: [
+        'data', 'desa', 'PP', 'pindah', 'undang',
+      ],
+    });
+  }
+
   /**
    *
    * The regex was tested in https://regex101.com/r/yySCn0/9
    * @inheritdoc
    */
   getRegex(): RegExp {
-    const dws = getDividerWords({ withTypos: true }).join('|');
+    const dws = this.getDividerWords().join('|');
 
     return new RegExp(
       `^(\\d{2}\\.\\d{2}\\.\\d{2}\\.\\d{4})\\s*\\d*\\s*(.+?)(?=$|\\s(?:${dws})\\b)`,
@@ -18,15 +27,17 @@ export default class VillageTransformer implements Transformer<Village, VillageC
   }
 
   prepareData(data: string[]) {
+    // The regex was tested in https://regex101.com/r/FfdNRZ/8
+    const dws = this.getDividerWords().join('|');
+    const villageNameRegex = new RegExp(`^(?!(?:${dws})\\b)([a-z.'()/\\- ]+?)$`, 'i');
     const mergedRows: string[] = [];
+    const colSize = 26;
 
     // Combine data spread across multiple rows.
     for (const row of data) {
-      // The regex was tested in https://regex101.com/r/FfdNRZ/8
-      const dws = getDividerWords({ withTypos: true }).join('|');
-      const villageNameRegex = new RegExp(`^(?!(?:${dws})\\b)([a-z.'()/\\- ]+?)$`, 'i');
-
-      if (row.match(villageNameRegex)) {
+      // The current row is most likely the rest of latest village name
+      // if the current row length <= column size
+      if (row.match(villageNameRegex) && row.length <= colSize) {
         const lastRow = mergedRows.pop();
 
         if (lastRow) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Contributing Guidelines](https://github.com/fityannugroho/idn-area/blob/main/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (**optional**, for bug fixes or features)
- [ ] Docs have been added / updated (**optional**, for bug fixes or features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: #8 

Problem with the CSV unparser quoting and escaping feature (e.g. `Do"a` to be `"Do\"a"`, and `One, Two` to be `"One, Two"`). See the diff-villages.txt in #8.

## What is the new behavior?

- Fix CSV unparser config to disable the quoting and escaping feature.
- Improve the village transformer by: 
  - Add new divider words ('koreksin')
  - Exclude some divider words
  - Add length limit (26 characters, follow the column width in the data source) for data row which is thought to be part of the village name

## Other information

Current data comparison (based on [REF-2022-2](https://github.com/fityannugroho/idn-area-data/blob/main/docs/references.md#REF-2022-2)):
- [diff-regencies.txt](https://github.com/fityannugroho/idn-area-extractor/files/12496766/diff-regencies.txt)
- [diff-districts.txt](https://github.com/fityannugroho/idn-area-extractor/files/12496807/diff-districts.txt)
- [diff-islands.txt](https://github.com/fityannugroho/idn-area-extractor/files/12496848/diff-islands.txt)
- [diff-villages.txt](https://github.com/fityannugroho/idn-area-extractor/files/12496853/diff-villages.txt)
