### PR TITLE
Handle common typos in the island's coordinate data

### DIFF
--- a/test/data/islands.txt
+++ b/test/data/islands.txt
@@ -1,6 +1,9 @@
 // Below are examples of island data extracted from a source file in PDF format
 
+11.01.40002 Pulau Batutunggal 03°24'55" U 097°04'21" T TBP
 13.00.40001 Pulau Bando 00°45'38.07" S 099°59'47.69" T
 21.71.40308 Pulau Petang 00°47'18.61" U 104°09'01.32" T TBP
 21.71.40309 Pulau Petong 00°37'37.99" U 104°05'28.00" T BP
 21.71.40320 Pulau Punai 01°04'42.60" U 103°52'24.10" T
+52.01.40031 Gili Sarang Timur 08°53'54.11"" S 116°02'58.02"" T TBP Perbaikan nama pulau semula
+71.03.40118 Pulau Balontohe Besar 03° 31'33.49" U 125° 39'37.53" T

--- a/test/transformer.spec.ts
+++ b/test/transformer.spec.ts
@@ -66,6 +66,14 @@ validateTransformer({
   data: extractTxtFileRows(path.resolve(__dirname, 'data/islands.txt')),
   expected: [
     {
+      code: '110140002',
+      regencyCode: '1101',
+      coordinate: '03°24\'55.00" N 097°04\'21.00" E',
+      isPopulated: false,
+      isOutermostSmall: false,
+      name: 'Pulau Batutunggal',
+    },
+    {
       code: '130040001',
       regencyCode: '',
       coordinate: '00°45\'38.07" S 099°59\'47.69" E',
@@ -96,6 +104,22 @@ validateTransformer({
       isPopulated: false,
       isOutermostSmall: false,
       name: 'Pulau Punai',
+    },
+    {
+      code: '520140031',
+      regencyCode: '5201',
+      coordinate: '08°53\'54.11" S 116°02\'58.02" E',
+      isPopulated: false,
+      isOutermostSmall: false,
+      name: 'Gili Sarang Timur',
+    },
+    {
+      code: '710340118',
+      regencyCode: '7103',
+      coordinate: '03°31\'33.49" N 125°39\'37.53" E',
+      isPopulated: false,
+      isOutermostSmall: false,
+      name: 'Pulau Balontohe Besar',
     },
   ],
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [Contributing Guidelines](https://github.com/fityannugroho/idn-area/blob/main/CONTRIBUTING.md)
- [x] Tests for the changes have been added (**optional**, for bug fixes or features)
- [ ] Docs have been added / updated (**optional**, for bug fixes or features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

Issue Number: N/A

Currently, the island data is ignored if there are any typos in the island's coordinate data, like described below:

| Common Typos | Example | Expected |
|---|---|---|
| Unnecessary spacing | `03° 31'33.49" U 125° 39'37.53" T` | `03°31'33.49" U 125°39'37.53" T` |
| Double hit | `08°53'54.11"" S 116°02'58.02"" T` | `08°53'54.11" S 116°02'58.02" T` |
| Non-uniform decimals | `03°24'55" U 097°04'21" T` | `03°24'55.00" U 097°04'21.00" T` |

## What is the new behavior?

Update the `IslandTransformer` to resolve common typos in the island's coordinate data.

## Other information

None