### PR TITLE
Fix resolving `destination` path and auto generate it if doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ USAGE
 
 OPTIONS
   -c, --compare             Compare the extracted data with the latest data
-  -d, --destination=<path>  Set the folder destination
+  -d, --destination=<path>  Set the folder destination. Default: current working directory
   -o, --output=<filename>   Set a specific output file name without the file extension
   -r, --range=<range>       Extract specific PDF pages (e.g. 1-2,5,7-10)
   -R, --save-raw            Save the extracted raw data into .txt file (only works with PDF data)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,7 +91,7 @@ async function main() {
     }
 
     flags.destination = await input({
-      message: 'Enter the destination folder:',
+      message: 'Set specific destination folder?',
     });
 
     flags.output = await input({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ const cli = meow(`
 
   OPTIONS
     -c, --compare             Compare the extracted data with the latest data
-    -d, --destination=<path>  Set the folder destination
+    -d, --destination=<path>  Set the folder destination. Default: current working directory
     -o, --output=<filename>   Set a specific output file name without the file extension
     -r, --range=<range>       Extract specific PDF pages (e.g. 1-2,5,7-10)
     -R, --save-raw            Save the extracted raw data into .txt file (only works with PDF data)
@@ -92,7 +92,6 @@ async function main() {
 
     flags.destination = await input({
       message: 'Enter the destination folder:',
-      default: process.cwd(),
     });
 
     flags.output = await input({

--- a/src/errors/DirectoryError.ts
+++ b/src/errors/DirectoryError.ts
@@ -1,0 +1,6 @@
+export default class DirectoryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DirectoryError';
+  }
+}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -76,13 +76,7 @@ describe('idnxtr', () => {
 
     it('should throw error if destination is not a folder path', async () => {
       await expect(idnxtr({ data: 'regencies', filePath, destination: filePath }))
-        .rejects.toThrow("'destination' must be a directory path");
-
-      await expect(idnxtr({ data: 'regencies', filePath, destination: ` ${distPath}` }))
-        .rejects.toThrow("'destination' must be a directory path");
-
-      await expect(idnxtr({ data: 'regencies', filePath, destination: `${distPath} ` }))
-        .rejects.toThrow("'destination' must be a directory path");
+        .rejects.toThrow("'destination' must be a valid directory path");
     });
 
     it('should throw error if output is exists but empty', async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [x] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

The `destination` must be an existing absolute directory path.

## What is the new behavior?

The `destination` can be a new directory path, either absolute or relative path. It will be created automatically if doesn't exists.

## Other information

None
